### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -9,6 +9,8 @@ jobs:
   check:
     name: Check for new YOURLS release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       old:   ${{ steps.check.outputs.old }}
       new:   ${{ steps.check.outputs.new }}
@@ -48,6 +50,8 @@ jobs:
   create_patch:
     name: Generate & publish patch
     needs: check
+    permissions:
+      contents: write
     if: needs.check.outputs.proceed == 'true'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/gioxx/YOURLS-diff/security/code-scanning/1](https://github.com/gioxx/YOURLS-diff/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow to explicitly define the minimal permissions required for each job. The `check` job only needs `contents: read` to fetch release information from the repository. The `create_patch` job requires `contents: read` to access the repository and `contents: write` to create a release and upload artifacts. These permissions will be added at the job level to ensure each job has only the permissions it needs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
